### PR TITLE
add local timezone conversion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,6 +1110,22 @@ If the commands above did not work well, or if you want to install older version
   </details>
 
   <details>
+  <summary><code>local</code></summary>
+
+  $t: time \rightarrow u: time$
+
+  - $t$: $time$ object
+    - $t$ must be specified via the input stream
+  - $u$: time $t$ in local timezone
+
+  e.g.)
+  ```
+  $ dq 'local | .timezone.short'
+  "JST"
+  ```
+  </details>
+
+  <details>
   <summary><code>hours</code></summary>
 
   $h: integer \rightarrow d: duration$

--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -437,6 +437,15 @@ func UTC(v interface{}, _ []interface{}) interface{} {
 	return errors.New("unexpected type")
 }
 
+func Local(v interface{}, _ []interface{}) interface{} {
+	t, ok := DecapTime(v)
+	if ok {
+		return EncapTime(t.Local())
+	}
+
+	return errors.New("unexpected type")
+}
+
 func Hours(v interface{}, args []interface{}) interface{} {
 	if len(args) == 1 {
 		v = args[0]

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -140,6 +140,7 @@ func (c *CLI) run(args []string) error {
 		gojq.WithFunction("clock", 0, 0, builtin.Clock),
 		gojq.WithFunction("date", 0, 0, builtin.Date),
 		gojq.WithFunction("utc", 0, 0, builtin.UTC),
+		gojq.WithFunction("local", 0, 0, builtin.Local),
 		gojq.WithFunction("hours", 0, 1, builtin.Hours),
 		gojq.WithFunction("minutes", 0, 1, builtin.Minutes),
 		gojq.WithFunction("seconds", 0, 1, builtin.Seconds),


### PR DESCRIPTION
Sometimes it's convenient to have the ability to convert a given date and time to local time.